### PR TITLE
translate native-modules-intro.md

### DIFF
--- a/docs/native-modules-intro.md
+++ b/docs/native-modules-intro.md
@@ -1,9 +1,9 @@
 ---
 id: native-modules-intro
-title: Native Modules Intro
+title: はじめてのネイティブモジュール
 ---
 
-Sometimes a React Native app needs to access a native platform API that is not available by default in JavaScript, for example the native APIs to access Apple or Android pay. Maybe you want to reuse some existing Objective-C, Swift, Java or C++ libraries without having to reimplement it in JavaScript, or write some high performance, multi-threaded code for things like image processing.
+React Native でアプリを作っていると、JavaScript 向けの API が標準で提供されていない、各プラットフォームのネイティブな API にアクセスしたくなることがあります。Apple Pay や Android Pay にアクセスするためのネイティブな API はその一例です。きっと皆さんは、Objective-C や Swift、Java、C++などで実装された既存のライブラリを再利用したいでしょうし、それらを JavaScript で再実装するのは避けたいことでしょう。あるいは、画像処理などのために、ハイパフォーマンスかつマルチスレッドなコードをいくらか書きたいこともあるでしょう。
 
 The NativeModule system exposes instances of Java/Objective-C/C++ (native) classes to JavaScript (JS) as JS objects, thereby allowing you to execute arbitrary native code from within JS. While we don't expect this feature to be part of the usual development process, it is essential that it exists. If React Native doesn't export a native API that your JS app needs you should be able to export it yourself!
 


### PR DESCRIPTION
## 原本についての既知の課題メモ

- Android Payは現在Google Payである
- 列挙される言語にKotlinを加えるべきである