### PR TITLE
Add textlint rule preset ja spacing

### DIFF
--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -9,5 +9,9 @@ rules:
     "ja-space-around-code":
       "before": true
       "after": true
+    "ja-no-space-around-parentheses": false
+    "ja-nakaguro-or-halfwidth-space-between-katakana": false
+    "ja-space-after-exclamation": false
+    "ja-space-after-question": false
   "@proofdict/proofdict":
     dictURL: https://react-native-jp.github.io/proof-dictionary/

--- a/.textlintrc.yml
+++ b/.textlintrc.yml
@@ -3,5 +3,11 @@ filters: {}
 rules:
   preset-ja-technical-writing: true
   "@textlint-ja/no-synonyms": true
+  "preset-ja-spacing": 
+    "ja-space-between-half-and-full-width":
+      "space": "always"
+    "ja-space-around-code":
+      "before": true
+      "after": true
   "@proofdict/proofdict":
     dictURL: https://react-native-jp.github.io/proof-dictionary/

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "pretty-quick": "^3.1.0",
     "sudachi-synonyms-dictionary": "^6.0.0",
     "textlint": "^11.8.2",
+    "textlint-rule-preset-ja-spacing": "^2.0.2",
     "textlint-rule-preset-ja-technical-writing": "^4.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12108,6 +12108,14 @@ textlint-rule-helper@^2.0.0, textlint-rule-helper@^2.1.1:
     structured-source "^3.0.2"
     unist-util-visit "^1.1.0"
 
+textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana/-/textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana-2.0.2.tgz#53eca84fec334e781207ca883a7f3bdf8444cfdd"
+  integrity sha512-o30z8Lw3qnaF+yMjwZC7f0zEyMHrUAP/nI3fNAJGREudnSO+Vo1fynFuIkd4FRWW2o448dS6pG/84swvzLWUyw==
+  dependencies:
+    match-index "^1.0.3"
+    textlint-rule-helper "^2.1.1"
+
 textlint-rule-ja-no-abusage@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-abusage/-/textlint-rule-ja-no-abusage-2.0.1.tgz#cd07bea78a2dec65b4128f8d49e104d44f9084d9"
@@ -12137,6 +12145,23 @@ textlint-rule-ja-no-redundant-expression@^3.0.2:
     textlint-rule-helper "^2.1.1"
     textlint-util-to-string "^3.1.1"
 
+textlint-rule-ja-no-space-around-parentheses@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-space-around-parentheses/-/textlint-rule-ja-no-space-around-parentheses-2.0.2.tgz#0f628c4cbfa7b8e918e1e650b55faf5c77b438ad"
+  integrity sha512-GYjwujWlY6AEuTRrusCv3MPnim8DcPXF4J+l3YL8P17DuxFI0/yhR3t1L2UNErvxf0Uv4ymg4gHHN4RAkbRdyw==
+  dependencies:
+    match-index "^1.0.3"
+    textlint-rule-helper "^2.1.1"
+
+textlint-rule-ja-no-space-between-full-width@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-space-between-full-width/-/textlint-rule-ja-no-space-between-full-width-2.0.2.tgz#81c2d0f071d753270ca0c44ad4a3573bc41fd2a6"
+  integrity sha512-uTfjDY5W+GtmeuAKasDVAsOZHX5cZ7Id8QOKRtODE9VtuGY7ACDeJn20NR8YbFVh4sz55LaZasW95XR+RDo++g==
+  dependencies:
+    match-index "^1.0.3"
+    regx "^1.0.4"
+    textlint-rule-helper "^2.1.1"
+
 textlint-rule-ja-no-successive-word@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/textlint-rule-ja-no-successive-word/-/textlint-rule-ja-no-successive-word-1.2.0.tgz#ba7597b54978388a5f8e53b9003bd9066f2111ad"
@@ -12153,6 +12178,38 @@ textlint-rule-ja-no-weak-phrase@^1.0.5:
     kuromojin "^2.0.0"
     morpheme-match "^2.0.4"
     morpheme-match-all "^2.0.5"
+
+textlint-rule-ja-space-after-exclamation@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-space-after-exclamation/-/textlint-rule-ja-space-after-exclamation-2.0.2.tgz#31493e6ec3f3e33a125c42a738cc2fd26b839817"
+  integrity sha512-AcnOKT4xCYZiR7iueUIkTlO+0ZAV246cbD/keaVXUQI3RwK0Bdgc6yORxqICHi2WxHJICmKsJaggVQTO7pWQiQ==
+  dependencies:
+    match-index "^1.0.3"
+    textlint-rule-helper "^2.1.1"
+
+textlint-rule-ja-space-after-question@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-space-after-question/-/textlint-rule-ja-space-after-question-2.0.2.tgz#a3efd17acdd36e5aa0d274edd20e6e2776bb3424"
+  integrity sha512-4VDYzxYwrb0kgHKykjzbHvr+MeMBW5YV+0/P6iJmznsNLGw8D9vBEqshG2njxdaOdxxVzwwd0uPJWyKGuDq5ZA==
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
+
+textlint-rule-ja-space-around-code@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-space-around-code/-/textlint-rule-ja-space-around-code-2.0.2.tgz#b107ce38048f2923820c9fe143f7d93477d56d32"
+  integrity sha512-ER4+dnu1ORusQT4bcF4Z4tB4wpDRNcL3a2lZlpug/4YG62L3WrISGUMUWpHaEXLu+QdqNq2hPo2O6L2r2PMmhA==
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
+
+textlint-rule-ja-space-between-half-and-full-width@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-space-between-half-and-full-width/-/textlint-rule-ja-space-between-half-and-full-width-2.0.2.tgz#c22dc52759e26ff7c65f5c0bb7c80ec3a7793dfa"
+  integrity sha512-M/lZvaB3RyjJobvJx1leXC51AIhI+UoC3tO2U4DxBRuTiBiy2vaegFzNPpfVkLKTF+cY012CdMXK1aiy0NottQ==
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^2.0.0"
 
 textlint-rule-ja-unnatural-alphabet@2.0.1:
   version "2.0.1"
@@ -12268,6 +12325,19 @@ textlint-rule-no-nfd@^1.0.2:
     match-index "^1.0.3"
     textlint-rule-helper "^2.1.1"
     unorm "^1.4.1"
+
+textlint-rule-preset-ja-spacing@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/textlint-rule-preset-ja-spacing/-/textlint-rule-preset-ja-spacing-2.0.2.tgz#1189c48a1bd81995645bcd7bcb2df041dc125476"
+  integrity sha512-GoGNeryeqJBCNJWoCikik7mD0Vx763y7xF73C0Omml6njljStuIeNab9SMaJqZlp0X6J+4daaR3jdyB9l/vm6g==
+  dependencies:
+    textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana "^2.0.2"
+    textlint-rule-ja-no-space-around-parentheses "^2.0.2"
+    textlint-rule-ja-no-space-between-full-width "^2.0.2"
+    textlint-rule-ja-space-after-exclamation "^2.0.2"
+    textlint-rule-ja-space-after-question "^2.0.2"
+    textlint-rule-ja-space-around-code "^2.0.2"
+    textlint-rule-ja-space-between-half-and-full-width "^2.0.2"
 
 textlint-rule-preset-ja-technical-writing@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->

## WHAT
textlint設定
[textlint-rule-preset-ja-spacing](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/) をinstall

### ON設定
- インラインコードの周りをスペースで囲む `ja-space-between-half-and-full-width`
- 半角文字と全角文字の間にスペースを入れる `ja-space-around-code`
- 全角文字同士の間のスペースについてのtextlintルール。 全角文字どうしの間にスペースを入れない `textlint-rule-ja-no-space-between-full-width`
  - デフォルト設定でONのルール。これはONのままでいいかなと思ったので、そのままにしてます

### OFF設定
[デフォルト設定](https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/#%E3%83%87%E3%83%95%E3%82%A9%E3%83%AB%E3%83%88%E8%A8%AD%E5%AE%9A)の中で、いくつか今は一旦OFFにしたいのがあったので、OFFにしました。

- ja-no-space-around-parentheses
- ja-nakaguro-or-halfwidth-space-between-katakana
- ja-space-after-exclamation
- ja-space-after-question

## WHY

merge済みのPRで、

- 読みやすさ重視のために、半角と全角の文字の間にはスペースを入れるようになってる
 - https://github.com/react-native-jp/react-native-website/pull/9 このPRで議論されてる
- インラインコードの周りをスペースで囲むようにもなってる

ので、textlint-rule-preset-ja-spacing を使用


## 動作確認

### インラインコードの周りをスペースで囲まないとエラーになる
<img width="191" alt="スクリーンショット 2021-02-19 21 53 55" src="https://user-images.githubusercontent.com/20507786/108506994-07e9fe80-72fd-11eb-92cb-a4186e387c3e.png">
<img width="576" alt="スクリーンショット 2021-02-19 21 57 11" src="https://user-images.githubusercontent.com/20507786/108507309-7c24a200-72fd-11eb-8a40-a33346fd2b59.png">



### 半角文字と全角文字の間にスペースを入れないとエラーになる
<img width="146" alt="スクリーンショット 2021-02-19 21 56 47" src="https://user-images.githubusercontent.com/20507786/108507304-79c24800-72fd-11eb-8a8f-6cf2966a82e4.png">
<img width="575" alt="スクリーンショット 2021-02-19 21 57 22" src="https://user-images.githubusercontent.com/20507786/108507315-7d55cf00-72fd-11eb-9210-c3869489e30f.png">

